### PR TITLE
Lower line length to 80.

### DIFF
--- a/linters/.rubocop.yml
+++ b/linters/.rubocop.yml
@@ -24,7 +24,13 @@ Style/RedundantSelf:
   Enabled: false
 
 Metrics/LineLength:
-  Max: 100
+  Max: 120
+
+Style/WhileUntilModifier:
+  MaxLineLength: 120
+
+Metrics/LineLength:
+  Max: 120
 
 Metrics/MethodLength:
   Max: 5

--- a/linters/.rubocop.yml
+++ b/linters/.rubocop.yml
@@ -24,13 +24,13 @@ Style/RedundantSelf:
   Enabled: false
 
 Metrics/LineLength:
-  Max: 120
+  Max: 80
 
 Style/WhileUntilModifier:
-  MaxLineLength: 120
+  MaxLineLength: 80
 
 Metrics/LineLength:
-  Max: 120
+  Max: 80
 
 Metrics/MethodLength:
   Max: 5


### PR DESCRIPTION
Why:
- It is then a default for someone whereas 100 is a line length no one
  uses.

This change addresses the need by:
- Change max line lengths from 100 to 80 in the .rubocop.yml linter.
- Add the other two rubocop line length settings that were missing.
