### PR TITLE
Fix rubocop.yml.

### DIFF
--- a/linters/.rubocop.yml
+++ b/linters/.rubocop.yml
@@ -160,13 +160,24 @@ Style/StringLiteralsInInterpolation:
   - single_quotes
   - double_quotes
 
-Style/TrailingComma:
-  Description: Checks for trailing comma in parameter lists and literals.
-  StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-trailing-array-commas
+Style/TrailingCommaInArguments:
+  Description: 'Checks for trailing comma in argument lists.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-trailing-array-commas'
   Enabled: true
   EnforcedStyleForMultiline: no_comma
   SupportedStyles:
   - comma
+  - consistent_comma
+  - no_comma
+
+Style/TrailingCommaInLiteral:
+  Description: 'Checks for trailing comma in array and hash literals.'
+  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-trailing-array-commas'
+  Enabled: true
+  EnforcedStyleForMultiline: no_comma
+  SupportedStyles:
+  - comma
+  - consistent_comma
   - no_comma
 
 Metrics/AbcSize:

--- a/linters/.rubocop.yml
+++ b/linters/.rubocop.yml
@@ -1,5 +1,4 @@
 AllCops:
-  RunRailsCops: true
   DisplayCopNames: true
   Include:
     - '**/Rakefile'
@@ -13,6 +12,9 @@ AllCops:
     - 'script/**/*'
     - 'vendor/**/*'
     - !ruby/regexp /old_and_unused\.rb$/
+
+Rails:
+  Enabled: true
 
 Rails/HasAndBelongsToMany:
   Enabled: false


### PR DESCRIPTION
Why:
- The old Style/TrailingComma cop breaks codeclimate.

This change addresses the need by:
- Replace Style/TrailingComma with Style/TrailingCommaInArguments and
  Style/TrailingCommaInLiteral.
